### PR TITLE
feat: no-drop-foreign-key-constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ module.exports = {
     'no-add-column-without-default': { enabled: true, severity: 'warning' },
     'require-foreign-key-cascade': { enabled: true, severity: 'warning' },
     'no-unique-constraint-without-index': { enabled: true, severity: 'warning' },
+    'no-drop-foreign-key-constraint': { enabled: true, severity: 'warning' },
     'require-index-for-foreign-key': { enabled: true, severity: 'warning' },
     'no-full-table-scan': { enabled: true, severity: 'warning' },
     'require-not-null-constraint': { enabled: false, severity: 'info' },
@@ -101,6 +102,10 @@ module.exports = {
 - **`no-unique-constraint-without-index`**: Warns about unique constraints that may fail
   - Severity: `warning`
   - Recommendation: Check for duplicates before adding unique constraints
+
+- **`no-drop-foreign-key-constraint`**: Warns about dropping foreign key constraints
+  - Severity: `warning`
+  - Recommendation: Ensure data consistency is maintained through application logic if constraint is removed
 
 ### Performance
 

--- a/src/__tests__/schema-safety.test.ts
+++ b/src/__tests__/schema-safety.test.ts
@@ -1,0 +1,175 @@
+import { noDropForeignKeyConstraintRule } from '../rules/schema-safety/no-drop-foreign-key-constraint';
+import { Migration, SQLStatement, Severity, RuleCategory } from '../types';
+
+describe('Schema Safety Rules', () => {
+  const createMockMigration = (content: string, statements: SQLStatement[]): Migration => ({
+    id: '20231201120000',
+    filename: 'test-migration.sql',
+    content,
+    statements
+  });
+
+  describe('No Drop Foreign Key Constraint Rule', () => {
+    it('should detect standard DROP CONSTRAINT for foreign key', () => {
+      const statement: SQLStatement = {
+        type: 'ALTER_TABLE',
+        content: 'ALTER TABLE orders DROP CONSTRAINT fk_orders_customer_id;',
+        startLine: 1,
+        endLine: 1
+      };
+      
+      const migration = createMockMigration(statement.content, [statement]);
+      const violations = noDropForeignKeyConstraintRule.check(statement, migration);
+      
+      expect(violations).toHaveLength(1);
+      expect(violations[0].ruleId).toBe('no-drop-foreign-key-constraint');
+      expect(violations[0].ruleName).toBe('No Drop Foreign Key Constraint');
+      expect(violations[0].severity).toBe(Severity.WARNING);
+      expect(violations[0].category).toBe(RuleCategory.SCHEMA_SAFETY);
+      expect(violations[0].message).toBe('Dropping foreign key constraints removes referential integrity protection');
+      expect(violations[0].line).toBe(1);
+      expect(violations[0].suggestion).toContain('data consistency');
+    });
+
+    it('should detect MySQL DROP FOREIGN KEY syntax', () => {
+      const statement: SQLStatement = {
+        type: 'ALTER_TABLE',
+        content: 'ALTER TABLE orders DROP FOREIGN KEY fk_orders_customer_id;',
+        startLine: 2,
+        endLine: 2
+      };
+      
+      const migration = createMockMigration(statement.content, [statement]);
+      const violations = noDropForeignKeyConstraintRule.check(statement, migration);
+      
+      expect(violations).toHaveLength(1);
+      expect(violations[0].ruleId).toBe('no-drop-foreign-key-constraint');
+      expect(violations[0].line).toBe(2);
+    });
+
+    it('should detect DROP INDEX for foreign key indexes', () => {
+      const statement: SQLStatement = {
+        type: 'ALTER_TABLE',
+        content: 'ALTER TABLE orders DROP INDEX FK_orders_customer_id;',
+        startLine: 3,
+        endLine: 3
+      };
+      
+      const migration = createMockMigration(statement.content, [statement]);
+      const violations = noDropForeignKeyConstraintRule.check(statement, migration);
+      
+      expect(violations).toHaveLength(1);
+      expect(violations[0].ruleId).toBe('no-drop-foreign-key-constraint');
+      expect(violations[0].line).toBe(3);
+    });
+
+    it('should detect DROP CONSTRAINT with FK_ naming pattern', () => {
+      const statement: SQLStatement = {
+        type: 'ALTER_TABLE',
+        content: 'ALTER TABLE orders DROP CONSTRAINT FK_orders_product;',
+        startLine: 4,
+        endLine: 4
+      };
+      
+      const migration = createMockMigration(statement.content, [statement]);
+      const violations = noDropForeignKeyConstraintRule.check(statement, migration);
+      
+      expect(violations).toHaveLength(1);
+      expect(violations[0].ruleId).toBe('no-drop-foreign-key-constraint');
+      expect(violations[0].line).toBe(4);
+    });
+
+    it('should detect DROP CONSTRAINT with _FK suffix pattern', () => {
+      const statement: SQLStatement = {
+        type: 'ALTER_TABLE',
+        content: 'ALTER TABLE orders DROP CONSTRAINT orders_customer_FK;',
+        startLine: 5,
+        endLine: 5
+      };
+      
+      const migration = createMockMigration(statement.content, [statement]);
+      const violations = noDropForeignKeyConstraintRule.check(statement, migration);
+      
+      expect(violations).toHaveLength(1);
+      expect(violations[0].ruleId).toBe('no-drop-foreign-key-constraint');
+      expect(violations[0].line).toBe(5);
+    });
+
+    it('should handle case insensitive SQL', () => {
+      const statement: SQLStatement = {
+        type: 'ALTER_TABLE',
+        content: 'alter table orders drop constraint fk_orders_customer_id;',
+        startLine: 6,
+        endLine: 6
+      };
+      
+      const migration = createMockMigration(statement.content, [statement]);
+      const violations = noDropForeignKeyConstraintRule.check(statement, migration);
+      
+      expect(violations).toHaveLength(1);
+      expect(violations[0].ruleId).toBe('no-drop-foreign-key-constraint');
+    });
+
+    it('should NOT trigger for non-foreign key constraint drops', () => {
+      const statements: SQLStatement[] = [
+        {
+          type: 'ALTER_TABLE',
+          content: 'ALTER TABLE users DROP CONSTRAINT check_age_positive;',
+          startLine: 1,
+          endLine: 1
+        },
+        {
+          type: 'ALTER_TABLE',
+          content: 'ALTER TABLE users DROP CONSTRAINT unique_email;',
+          startLine: 2,
+          endLine: 2
+        }
+      ];
+
+      statements.forEach(statement => {
+        const migration = createMockMigration(statement.content, [statement]);
+        const violations = noDropForeignKeyConstraintRule.check(statement, migration);
+        expect(violations).toHaveLength(0);
+      });
+    });
+
+    it('should NOT trigger for other ALTER TABLE operations', () => {
+      const statements: SQLStatement[] = [
+        {
+          type: 'ALTER_TABLE',
+          content: 'ALTER TABLE users ADD COLUMN email VARCHAR(255);',
+          startLine: 1,
+          endLine: 1
+        },
+        {
+          type: 'ALTER_TABLE',
+          content: 'ALTER TABLE users ADD CONSTRAINT fk_user_role FOREIGN KEY (role_id) REFERENCES roles(id);',
+          startLine: 2,
+          endLine: 2
+        },
+        {
+          type: 'ALTER_TABLE',
+          content: 'ALTER TABLE users MODIFY COLUMN name VARCHAR(100);',
+          startLine: 3,
+          endLine: 3
+        }
+      ];
+
+      statements.forEach(statement => {
+        const migration = createMockMigration(statement.content, [statement]);
+        const violations = noDropForeignKeyConstraintRule.check(statement, migration);
+        expect(violations).toHaveLength(0);
+      });
+    });
+
+    it('should have correct rule metadata', () => {
+      expect(noDropForeignKeyConstraintRule.id).toBe('no-drop-foreign-key-constraint');
+      expect(noDropForeignKeyConstraintRule.name).toBe('No Drop Foreign Key Constraint');
+      expect(noDropForeignKeyConstraintRule.description).toBe('Dropping foreign key constraints removes referential integrity checks and can lead to data inconsistencies');
+      expect(noDropForeignKeyConstraintRule.severity).toBe(Severity.WARNING);
+      expect(noDropForeignKeyConstraintRule.category).toBe(RuleCategory.SCHEMA_SAFETY);
+      expect(noDropForeignKeyConstraintRule.enabled).toBe(true);
+      expect(noDropForeignKeyConstraintRule.recommendation).toBe('Consider if dropping the foreign key constraint is necessary. Ensure proper data validation in application code if removed.');
+    });
+  });
+}); 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -121,6 +121,7 @@ export class ConfigManager {
     'no-add-column-without-default': { enabled: true, severity: 'warning' },
     'require-foreign-key-cascade': { enabled: true, severity: 'warning' },
     'no-unique-constraint-without-index': { enabled: true, severity: 'warning' },
+    'no-drop-foreign-key-constraint': { enabled: true, severity: 'warning' },
     
     // Performance Rules - Warnings for potential performance issues
     'require-index-for-foreign-key': { enabled: true, severity: 'warning' },

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -7,6 +7,7 @@ import { requireForeignKeyCascadeRule } from './schema-safety/require-foreign-ke
 import { noUniqueConstraintWithoutIndexRule } from './schema-safety/no-unique-constraint-without-index';
 import { noColumnRenameRule } from './schema-safety/no-column-rename';
 import { noTableRenameRule } from './schema-safety/no-table-rename';
+import { noDropForeignKeyConstraintRule } from './schema-safety/no-drop-foreign-key-constraint';
 
 import { requireIndexForForeignKeyRule } from './performance/require-index-for-foreign-key';
 import { noFullTableScanRule } from './performance/no-full-table-scan';
@@ -31,6 +32,7 @@ export const BUILT_IN_RULES: Record<string, Rule> = {
   'no-unique-constraint-without-index': noUniqueConstraintWithoutIndexRule,
   'no-column-rename': noColumnRenameRule,
   'no-table-rename': noTableRenameRule,
+  'no-drop-foreign-key-constraint': noDropForeignKeyConstraintRule,
   
   // Performance Rules
   'require-index-for-foreign-key': requireIndexForForeignKeyRule,

--- a/src/rules/schema-safety/no-drop-foreign-key-constraint.ts
+++ b/src/rules/schema-safety/no-drop-foreign-key-constraint.ts
@@ -1,0 +1,42 @@
+import { Rule, Severity, RuleCategory, SQLStatement, Migration, Violation } from '../../types';
+
+export const noDropForeignKeyConstraintRule: Rule = {
+  id: 'no-drop-foreign-key-constraint',
+  name: 'No Drop Foreign Key Constraint',
+  description: 'Dropping foreign key constraints removes referential integrity checks and can lead to data inconsistencies',
+  severity: Severity.WARNING,
+  category: RuleCategory.SCHEMA_SAFETY,
+  enabled: true,
+  recommendation: 'Consider if dropping the foreign key constraint is necessary. Ensure proper data validation in application code if removed.',
+  check: (statement: SQLStatement, migration: Migration): Violation[] => {
+    const violations: Violation[] = [];
+
+    if (statement.type === 'ALTER_TABLE') {
+      const content = statement.content.toUpperCase();
+      
+      // Check for different syntax patterns for dropping foreign key constraints
+      const isDroppingForeignKey = (
+        // MySQL specific: DROP FOREIGN KEY constraint_name
+        (content.includes('DROP FOREIGN KEY')) ||
+        // Some databases: DROP INDEX constraint_name (for foreign key indexes with FK naming)
+        (content.includes('DROP INDEX') && content.includes('FK_')) ||
+        // Generic pattern for foreign key constraint names with FK prefix or suffix
+        (content.includes('DROP CONSTRAINT') && (content.includes('FK_') || content.includes('_FK')))
+      );
+
+      if (isDroppingForeignKey) {
+        violations.push({
+          ruleId: 'no-drop-foreign-key-constraint',
+          ruleName: 'No Drop Foreign Key Constraint',
+          severity: Severity.WARNING,
+          message: 'Dropping foreign key constraints removes referential integrity protection',
+          line: statement.startLine,
+          suggestion: 'Ensure data consistency is maintained through application logic or consider if the constraint drop is truly necessary',
+          category: RuleCategory.SCHEMA_SAFETY
+        });
+      }
+    }
+
+    return violations;
+  }
+}; 


### PR DESCRIPTION
## Description

This PR introduces a new schema safety rule: `no-drop-foreign-key-constraint`.

This rule aims to prevent accidental data inconsistencies by warning users when a migration attempts to drop a foreign key constraint. Dropping foreign key constraints removes referential integrity checks at the database level, which can lead to orphaned records or invalid relationships if not handled carefully in the application logic.

### Key Features:

*   **Detects Foreign Key Drops**: The rule identifies `ALTER TABLE` statements that drop foreign key constraints. It checks for various SQL syntax patterns, including:
    *   `DROP FOREIGN KEY constraint_name` (MySQL specific)
    *   `DROP INDEX constraint_name` (where `constraint_name` follows common foreign key naming conventions like `FK_...`)
    *   `DROP CONSTRAINT constraint_name` (where `constraint_name` follows common foreign key naming conventions like `FK_...` or `..._FK`)
*   **Severity**: The rule is enabled by default with a `warning` severity.
*   **Recommendation**: Advises users to consider the necessity of dropping the constraint and to ensure data consistency is maintained through application logic if the constraint is removed.

### Changes:

*   Added `no-drop-foreign-key-constraint.ts` with the rule logic.
*   Included comprehensive tests for the new rule in `schema-safety.test.ts` to cover various scenarios.
*   Updated `README.md` to document the new rule.
*   Registered the new rule in `src/rules/index.ts` and `src/core/config.ts`.