### PR TITLE
feat(cli): lint only changed files

### DIFF
--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -3,6 +3,7 @@ import { MigrationScanner } from './migration-scanner';
 import { RuleEngine } from './rule-engine';
 import { ConfigManager } from './config';
 import { getBuiltInRules } from '../rules';
+import { GitUtils, GitOptions } from '../utils/git';
 
 export class PrismaStrongMigrationsLinter {
   private scanner: MigrationScanner;
@@ -77,6 +78,96 @@ export class PrismaStrongMigrationsLinter {
       errorCount: violations.filter(v => v.severity === 'error').length,
       warningCount: violations.filter(v => v.severity === 'warning').length,
       infoCount: violations.filter(v => v.severity === 'info').length
+    };
+  }
+
+  async lintChangedMigrations(options: GitOptions = {}): Promise<LintResult> {
+    // Check if we're in a git repository
+    if (!GitUtils.isGitRepository()) {
+      throw new Error('Not in a git repository. Cannot detect changed files.');
+    }
+
+    const migrationsPath = this.configManager.getMigrationsPath();
+    
+    // Get changed migration files
+    const changedFiles = GitUtils.getChangedMigrationFiles(migrationsPath, options);
+    
+    if (changedFiles.length === 0) {
+      return {
+        violations: [],
+        totalFiles: 0,
+        totalViolations: 0,
+        errorCount: 0,
+        warningCount: 0,
+        infoCount: 0
+      };
+    }
+
+    // Lint each changed file
+    const allViolations = [];
+    for (const filePath of changedFiles) {
+      try {
+        const migration = await this.scanner.scanSingleMigration(filePath);
+        const violations = await this.ruleEngine.analyzeMigration(migration);
+        allViolations.push(...violations);
+      } catch (error) {
+        // Skip files that can't be read (e.g., deleted files)
+        console.warn(`Warning: Could not analyze migration file: ${filePath}`);
+      }
+    }
+
+    return {
+      violations: allViolations,
+      totalFiles: changedFiles.length,
+      totalViolations: allViolations.length,
+      errorCount: allViolations.filter(v => v.severity === 'error').length,
+      warningCount: allViolations.filter(v => v.severity === 'warning').length,
+      infoCount: allViolations.filter(v => v.severity === 'info').length
+    };
+  }
+
+  async lintChangedMigrationsSinceCommit(commitSha: string): Promise<LintResult> {
+    // Check if we're in a git repository
+    if (!GitUtils.isGitRepository()) {
+      throw new Error('Not in a git repository. Cannot detect changed files.');
+    }
+
+    const migrationsPath = this.configManager.getMigrationsPath();
+    
+    // Get changed migration files since commit
+    const changedFiles = GitUtils.getChangedMigrationFilesSinceCommit(migrationsPath, commitSha);
+    
+    if (changedFiles.length === 0) {
+      return {
+        violations: [],
+        totalFiles: 0,
+        totalViolations: 0,
+        errorCount: 0,
+        warningCount: 0,
+        infoCount: 0
+      };
+    }
+
+    // Lint each changed file
+    const allViolations = [];
+    for (const filePath of changedFiles) {
+      try {
+        const migration = await this.scanner.scanSingleMigration(filePath);
+        const violations = await this.ruleEngine.analyzeMigration(migration);
+        allViolations.push(...violations);
+      } catch (error) {
+        // Skip files that can't be read (e.g., deleted files)
+        console.warn(`Warning: Could not analyze migration file: ${filePath}`);
+      }
+    }
+
+    return {
+      violations: allViolations,
+      totalFiles: changedFiles.length,
+      totalViolations: allViolations.length,
+      errorCount: allViolations.filter(v => v.severity === 'error').length,
+      warningCount: allViolations.filter(v => v.severity === 'warning').length,
+      infoCount: allViolations.filter(v => v.severity === 'info').length
     };
   }
 

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -110,7 +110,7 @@ export class PrismaStrongMigrationsLinter {
         const migration = await this.scanner.scanSingleMigration(filePath);
         const violations = await this.ruleEngine.analyzeMigration(migration);
         allViolations.push(...violations);
-      } catch (error) {
+      } catch (_error) {
         // Skip files that can't be read (e.g., deleted files)
         console.warn(`Warning: Could not analyze migration file: ${filePath}`);
       }
@@ -155,7 +155,7 @@ export class PrismaStrongMigrationsLinter {
         const migration = await this.scanner.scanSingleMigration(filePath);
         const violations = await this.ruleEngine.analyzeMigration(migration);
         allViolations.push(...violations);
-      } catch (error) {
+      } catch (_error) {
         // Skip files that can't be read (e.g., deleted files)
         console.warn(`Warning: Could not analyze migration file: ${filePath}`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { SQLParser } from './core/sql-parser';
 
 export { getBuiltInRules, getBuiltInRule, createCustomRule } from './rules';
 export { ReporterFactory, TextReporter, JsonReporter, JunitReporter } from './reporters';
+export { GitUtils } from './utils/git';
 
 export * from './types';
 

--- a/src/utils/__tests__/git.test.ts
+++ b/src/utils/__tests__/git.test.ts
@@ -1,0 +1,181 @@
+import { GitUtils } from '../git';
+import { execSync } from 'child_process';
+
+// Mock execSync for testing
+jest.mock('child_process');
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+describe('GitUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isGitRepository', () => {
+    it('should return true when in a git repository', () => {
+      mockExecSync.mockReturnValue('');
+      
+      const result = GitUtils.isGitRepository();
+      
+      expect(result).toBe(true);
+      expect(mockExecSync).toHaveBeenCalledWith('git rev-parse --git-dir', { stdio: 'ignore' });
+    });
+
+    it('should return false when not in a git repository', () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('Not a git repository');
+      });
+      
+      const result = GitUtils.isGitRepository();
+      
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getCurrentBranch', () => {
+    it('should return the current branch name', () => {
+      mockExecSync.mockReturnValue('feature/test-branch\n');
+      
+      const result = GitUtils.getCurrentBranch();
+      
+      expect(result).toBe('feature/test-branch');
+      expect(mockExecSync).toHaveBeenCalledWith('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' });
+    });
+
+    it('should throw error when git command fails', () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('Not a git repository');
+      });
+      
+      expect(() => GitUtils.getCurrentBranch()).toThrow('Failed to get current branch');
+    });
+  });
+
+  describe('branchExists', () => {
+    it('should return true when branch exists', () => {
+      mockExecSync.mockReturnValue('');
+      
+      const result = GitUtils.branchExists('origin/main');
+      
+      expect(result).toBe(true);
+      expect(mockExecSync).toHaveBeenCalledWith('git rev-parse --verify origin/main', { stdio: 'ignore' });
+    });
+
+    it('should return false when branch does not exist', () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('Branch not found');
+      });
+      
+      const result = GitUtils.branchExists('nonexistent-branch');
+      
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getChangedMigrationFiles', () => {
+    it('should return changed migration files', () => {
+      // Mock fetch origin (silent)
+      mockExecSync.mockReturnValueOnce('');
+      
+      // Mock git diff output
+      const gitOutput = 'prisma/migrations/001_init/migration.sql\nprisma/migrations/002_add_users/migration.sql\nsrc/other-file.ts';
+      mockExecSync.mockReturnValueOnce(gitOutput);
+      
+      const result = GitUtils.getChangedMigrationFiles('prisma/migrations');
+      
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain('001_init/migration.sql');
+      expect(result[1]).toContain('002_add_users/migration.sql');
+    });
+
+    it('should return empty array when no migration files changed', () => {
+      // Mock fetch origin (silent)
+      mockExecSync.mockReturnValueOnce('');
+      
+      // Mock git diff output with no migration files
+      const gitOutput = 'src/other-file.ts\nREADME.md';
+      mockExecSync.mockReturnValueOnce(gitOutput);
+      
+      const result = GitUtils.getChangedMigrationFiles('prisma/migrations');
+      
+      expect(result).toHaveLength(0);
+    });
+
+    it('should return empty array when no files changed', () => {
+      // Mock fetch origin (silent)
+      mockExecSync.mockReturnValueOnce('');
+      
+      // Mock git diff output with empty result
+      mockExecSync.mockReturnValueOnce('');
+      
+      const result = GitUtils.getChangedMigrationFiles('prisma/migrations');
+      
+      expect(result).toHaveLength(0);
+    });
+
+    it('should use correct git command with options', () => {
+      // Mock fetch origin (silent)
+      mockExecSync.mockReturnValueOnce('');
+      
+      // Mock git diff output
+      mockExecSync.mockReturnValueOnce('');
+      
+      GitUtils.getChangedMigrationFiles('prisma/migrations', {
+        base: 'origin/develop',
+        addedOnly: true
+      });
+      
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'git diff --diff-filter=A --name-only origin/develop...HEAD',
+        { encoding: 'utf8' }
+      );
+    });
+
+    it('should throw error when git command fails', () => {
+      // Mock fetch origin (silent)
+      mockExecSync.mockReturnValueOnce('');
+      
+      // Mock git diff failure
+      mockExecSync.mockImplementation(() => {
+        throw new Error('Git command failed');
+      });
+      
+      expect(() => GitUtils.getChangedMigrationFiles('prisma/migrations')).toThrow(
+        'Failed to get changed migration files'
+      );
+    });
+  });
+
+  describe('getChangedMigrationFilesSinceCommit', () => {
+    it('should return changed migration files since commit', () => {
+      const gitOutput = 'prisma/migrations/001_init/migration.sql\nprisma/migrations/002_add_users/migration.sql';
+      mockExecSync.mockReturnValue(gitOutput);
+      
+      const result = GitUtils.getChangedMigrationFilesSinceCommit('prisma/migrations', 'abc123');
+      
+      expect(result).toHaveLength(2);
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'git diff --diff-filter=AM --name-only abc123...HEAD',
+        { encoding: 'utf8' }
+      );
+    });
+  });
+
+  describe('getMergeBase', () => {
+    it('should return the merge base commit', () => {
+      mockExecSync.mockReturnValue('abc123def456\n');
+      
+      const result = GitUtils.getMergeBase('origin/main');
+      
+      expect(result).toBe('abc123def456');
+      expect(mockExecSync).toHaveBeenCalledWith('git merge-base HEAD origin/main', { encoding: 'utf8' });
+    });
+
+    it('should throw error when git command fails', () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('No merge base found');
+      });
+      
+      expect(() => GitUtils.getMergeBase('origin/main')).toThrow('Failed to get merge base');
+    });
+  });
+}); 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,0 +1,164 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+
+export interface GitOptions {
+  /** Base branch to compare against (default: origin/main) */
+  base?: string;
+  /** Include only added files */
+  addedOnly?: boolean;
+  /** Include only modified files */
+  modifiedOnly?: boolean;
+  /** Include both added and modified files (default: true) */
+  includeAll?: boolean;
+}
+
+export class GitUtils {
+  /**
+   * Get the list of changed migration files compared to the base branch
+   */
+  static getChangedMigrationFiles(migrationsPath: string, options: GitOptions = {}): string[] {
+    const {
+      base = 'origin/main',
+      addedOnly = false,
+      modifiedOnly = false,
+      includeAll = true
+    } = options;
+
+    try {
+      // Ensure we have the latest refs
+      this.fetchOrigin();
+
+      let statusFilter = '';
+      if (addedOnly) {
+        statusFilter = '--diff-filter=A';
+      } else if (modifiedOnly) {
+        statusFilter = '--diff-filter=M';
+      } else if (includeAll) {
+        statusFilter = '--diff-filter=AM';
+      }
+
+      // Get changed files compared to base branch
+      const cmd = `git diff ${statusFilter} --name-only ${base}...HEAD`;
+      const output = execSync(cmd, { encoding: 'utf8' }).trim();
+      
+      if (!output) {
+        return [];
+      }
+
+      const changedFiles = output.split('\n');
+      
+      // Filter for migration files in the specified migrations path
+      const migrationFiles = changedFiles.filter(file => {
+        // Check if file is in migrations directory and is a SQL file
+        const normalizedMigrationsPath = path.normalize(migrationsPath);
+        const normalizedFile = path.normalize(file);
+        
+        return normalizedFile.startsWith(normalizedMigrationsPath) && 
+               normalizedFile.endsWith('.sql');
+      });
+
+      // Convert to absolute paths
+      return migrationFiles.map(file => path.resolve(file));
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get changed migration files: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Get changed migration files since a specific commit
+   */
+  static getChangedMigrationFilesSinceCommit(migrationsPath: string, commitSha: string): string[] {
+    try {
+      const cmd = `git diff --diff-filter=AM --name-only ${commitSha}...HEAD`;
+      const output = execSync(cmd, { encoding: 'utf8' }).trim();
+      
+      if (!output) {
+        return [];
+      }
+
+      const changedFiles = output.split('\n');
+      
+      // Filter for migration files
+      const migrationFiles = changedFiles.filter(file => {
+        const normalizedMigrationsPath = path.normalize(migrationsPath);
+        const normalizedFile = path.normalize(file);
+        
+        return normalizedFile.startsWith(normalizedMigrationsPath) && 
+               normalizedFile.endsWith('.sql');
+      });
+
+      return migrationFiles.map(file => path.resolve(file));
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get changed migration files since commit: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Check if we're in a git repository
+   */
+  static isGitRepository(): boolean {
+    try {
+      execSync('git rev-parse --git-dir', { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get the current branch name
+   */
+  static getCurrentBranch(): string {
+    try {
+      return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get current branch: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Check if a base branch exists
+   */
+  static branchExists(branchName: string): boolean {
+    try {
+      execSync(`git rev-parse --verify ${branchName}`, { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Fetch origin to ensure we have latest refs
+   */
+  private static fetchOrigin(): void {
+    try {
+      execSync('git fetch origin', { stdio: 'ignore' });
+    } catch {
+      // Ignore fetch errors - might be in CI or no network
+    }
+  }
+
+  /**
+   * Get the merge base between current branch and base branch
+   */
+  static getMergeBase(baseBranch: string): string {
+    try {
+      return execSync(`git merge-base HEAD ${baseBranch}`, { encoding: 'utf8' }).trim();
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get merge base: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+} 


### PR DESCRIPTION
This PR introduces the ability to lint only changed migration files, which is particularly useful for CI/CD pipelines and pull request checks.

**Key Changes:**

*   **New CLI Options:**
    *   `--changed`: Lints migration files that have changed compared to a base branch (defaults to `origin/main`).
        *   `--base <branch>`: Specifies the base branch for comparison.
        *   `--added-only`: When used with `--changed`, only lints newly added migration files.
        *   `--modified-only`: When used with `--changed`, only lints modified migration files.
    *   `--since-commit <sha>`: Lints migration files changed since a specific commit.
*   **Core Linter Updates:**
    *   Added `lintChangedMigrations` method to `PrismaStrongMigrationsLinter` to handle linting based on Git changes against a base branch.
    *   Added `lintChangedMigrationsSinceCommit` method to `PrismaStrongMigrationsLinter` to handle linting based on Git changes since a specific commit.
*   **Git Utilities:**
    *   Introduced a new `GitUtils` class (`src/utils/git.ts`) with methods like `isGitRepository`, `getCurrentBranch`, `branchExists`, `getChangedMigrationFiles`, `getChangedMigrationFilesSinceCommit`, and `getMergeBase`.
    *   Added corresponding tests for `GitUtils` in `src/utils/__tests__/git.test.ts`.
*   **Documentation (`README.md`):**
    *   Updated CLI usage section to include the new `--changed` and `--since-commit` options and their variants.
    *   Revised CI/CD integration examples (GitHub Actions, GitLab CI) to demonstrate linting only changed files, including fetching appropriate git history.
    *   Updated Programmatic Usage section to include `lintChangedMigrations`, `lintChangedMigrationsSinceCommit` and `GitUtils`.
*   **Exports:**
    *   Exported `GitUtils` from the main entry point (`src/index.ts`).
*   **CLI Enhancements (`src/cli.ts`):**
    *   Integrated the new linting options into the CLI command structure.
    *   Added checks for being in a Git repository and for the existence of the base branch when using `--changed`.
    *   Improved feedback messages to indicate which files are being linted or if no changed files are found.